### PR TITLE
add OSM key 'sport' to main tags

### DIFF
--- a/src/mainTags.json
+++ b/src/mainTags.json
@@ -19,6 +19,7 @@
   "railway",
   "route",
   "shop",
+  "sport",
   "tourism",
   "waterway"
 ]


### PR DESCRIPTION
Use case: find new bike parks which typically are mapped as leisure=pitch and sport=cycling

Rrelated to OSMCha/osmcha-frontend#645
